### PR TITLE
Add GigaAM long‑form transcription script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ SRT format.
 pip install gigaam[longform]
 ```
 
+For non-WAV inputs the script relies on `ffmpeg` being available in your `PATH` to
+convert other formats (mp3, m4a, flac, ...).
+
 You also need a [HuggingFace token](https://huggingface.co/docs/hub/security-tokens) in
 order to download the VAD models used for splitting long audio files.
 
 ## Usage
 
 ```bash
-python transcribe.py /path/to/audio.wav \
+python transcribe.py /path/to/audio.mp3 \
     --hf-token YOUR_TOKEN \
     --output subtitles.srt
 ```
@@ -28,4 +31,5 @@ Additional useful options:
 * `--max-duration`, `--min-duration`, `--new-chunk-threshold` – control how the audio is
   segmented before transcription.
 
-The script writes a UTF‑8 encoded `.srt` file with time-coded Russian subtitles.
+The script accepts any audio format supported by `ffmpeg` and writes a UTF‑8 encoded
+`.srt` file with time-coded Russian subtitles.


### PR DESCRIPTION
## Summary
- add `transcribe.py` to convert long Russian audio into SRT subtitles with GigaAM
- document installation, usage and options in README

## Testing
- `python transcribe.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b72c75f3748333b2df5e39eaf837c2