### PR TITLE
feat: transcribe multiple audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ order to download the VAD models used for splitting long audio files.
 ## Usage
 
 ```bash
-python transcribe.py /path/to/audio.mp3 \
-    --hf-token YOUR_TOKEN \
-    --output subtitles.srt
+python transcribe.py /path/to/audio1.mp3 /path/to/audio2.mp3 \
+    --hf-token YOUR_TOKEN
 ```
+
+For a single file you may also specify `--output subtitles.srt` to set the
+destination path. When multiple inputs are provided, `.srt` files are written
+next to each audio.
 
 Additional useful options:
 


### PR DESCRIPTION
## Summary
- allow passing multiple audio paths to `transcribe.py`
- reuse a single loaded model across files and save SRT next to each audio
- document multi-file usage in README

## Testing
- `python -m py_compile transcribe.py`
- `python transcribe.py --help` *(fails: ModuleNotFoundError: No module named 'gigaam')*
- `pip install gigaam[longform]` *(operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d2008e148333bc1bb26854ebda68