### PR TITLE
Add directory scanning for media without subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,21 @@ order to download the VAD models used for splitting long audio files.
 ```bash
 python transcribe.py /path/to/audio1.mp3 /path/to/audio2.mp3 \
     --hf-token YOUR_TOKEN
+
+# Transcribe every media file without an existing .srt next to it
+python transcribe.py /path/to/folder --recursive
 ```
 
 For a single file you may also specify `--output subtitles.srt` to set the
-destination path. When multiple inputs are provided, `.srt` files are written
-next to each audio.
+destination path. When multiple inputs (or directories) are provided, `.srt`
+files are written next to each media file without an existing subtitle.
 
 Additional useful options:
 
 * `--model` – choose `ctc` (default) or `rnnt` model.
 * `--device` – specify inference device, e.g. `cuda` or `cpu`.
+* `--recursive` – look through folders recursively for audio/video files without
+  an `.srt` subtitle.
 * `--max-duration`, `--min-duration`, `--new-chunk-threshold` – control how the audio is
   segmented before transcription.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Additional useful options:
 * `--device` – specify inference device, e.g. `cuda` or `cpu`.
 * `--recursive` – look through folders recursively for audio/video files without
   an `.srt` subtitle.
+* `--ignore-errors` / `--raise-errors` – keep processing other files after a failure
+  (default) or stop immediately to view the traceback.
+* `--logging` / `--no-logging` – turn informational logging on or off.
 * `--max-duration`, `--min-duration`, `--new-chunk-threshold` – control how the audio is
   segmented before transcription.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ python transcribe.py /path/to/audio1.mp3 /path/to/audio2.mp3 \
 
 # Transcribe every media file without an existing .srt next to it
 python transcribe.py /path/to/folder --recursive
+
+# Mix and match files and directories, or list directories explicitly
+python transcribe.py video.mp4 -d recordings/lectures -d recordings/meetups
 ```
 
 For a single file you may also specify `--output subtitles.srt` to set the
@@ -38,6 +41,8 @@ Additional useful options:
   an `.srt` subtitle.
 * `--ignore-errors` / `--raise-errors` – keep processing other files after a failure
   (default) or stop immediately to view the traceback.
+* `-d/--directory` – add one or more directories to scan in addition to positional
+  inputs.
 * `--logging` / `--no-logging` – turn informational logging on or off.
 * `--max-duration`, `--min-duration`, `--new-chunk-threshold` – control how the audio is
   segmented before transcription.

--- a/transcribe.py
+++ b/transcribe.py
@@ -142,7 +142,15 @@ def main() -> None:
         description="Transcribe audio into Russian SRT subtitles using GigaAM"
     )
     parser.add_argument(
-        "audio", nargs="+", help="Path(s) to input media file(s) or directories"
+        "inputs", nargs="*", help="Path(s) to input media file(s) or directories"
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        dest="directories",
+        action="append",
+        default=[],
+        help="Directory to scan for media files (can be specified multiple times)",
     )
     parser.add_argument(
         "-o",
@@ -221,8 +229,17 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.CRITICAL + 1)
 
+    combined_inputs: List[str] = []
+    if args.inputs:
+        combined_inputs.extend(args.inputs)
+    if args.directories:
+        combined_inputs.extend(args.directories)
+
+    if not combined_inputs:
+        parser.error("Please provide at least one media file or directory to process.")
+
     try:
-        audio_inputs = collect_media_paths(args.audio, args.recursive)
+        audio_inputs = collect_media_paths(combined_inputs, args.recursive)
     except (FileNotFoundError, ValueError) as exc:
         parser.error(str(exc))
 

--- a/transcribe.py
+++ b/transcribe.py
@@ -7,6 +7,7 @@ produces a standard ``.srt`` subtitle file.
 
 Example:
     python transcribe.py input1.mp3 input2.mp3 --hf-token YOUR_HF_TOKEN
+    python transcribe.py /path/to/folder --recursive
 
 Before running install dependencies:
     pip install gigaam[longform]
@@ -16,7 +17,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import List, Dict, Tuple
+from typing import Dict, Iterable, Iterator, List, Tuple
 
 import gigaam
 
@@ -67,12 +68,72 @@ def ensure_wav(path: str) -> Tuple[str, bool]:
     return tmp_path, True
 
 
+MEDIA_EXTENSIONS = {
+    ".aac",
+    ".aiff",
+    ".flac",
+    ".m4a",
+    ".mka",
+    ".mkv",
+    ".mov",
+    ".mp3",
+    ".mp4",
+    ".ogg",
+    ".opus",
+    ".wav",
+    ".webm",
+}
+
+
+def is_media_file(path: str) -> bool:
+    return os.path.splitext(path)[1].lower() in MEDIA_EXTENSIONS
+
+
+def has_adjacent_srt(path: str) -> bool:
+    return os.path.exists(os.path.splitext(path)[0] + ".srt")
+
+
+def _iter_directory_files(directory: str, recursive: bool) -> Iterator[str]:
+    if recursive:
+        for root, _, files in os.walk(directory):
+            for name in files:
+                yield os.path.join(root, name)
+    else:
+        for entry in os.scandir(directory):
+            if entry.is_file():
+                yield entry.path
+
+
+def collect_media_paths(inputs: Iterable[str], recursive: bool) -> List[str]:
+    discovered: List[str] = []
+    seen = set()
+    for original in inputs:
+        if not os.path.exists(original):
+            raise FileNotFoundError(f"Input path does not exist: {original}")
+        if os.path.isdir(original):
+            for candidate in _iter_directory_files(original, recursive):
+                if not is_media_file(candidate) or has_adjacent_srt(candidate):
+                    continue
+                if candidate not in seen:
+                    seen.add(candidate)
+                    discovered.append(candidate)
+            continue
+        if not is_media_file(original):
+            raise ValueError(f"Unsupported media file: {original}")
+        if has_adjacent_srt(original):
+            continue
+        if original not in seen:
+            seen.add(original)
+            discovered.append(original)
+    return discovered
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Transcribe audio into Russian SRT subtitles using GigaAM"
     )
     parser.add_argument(
-        "audio", nargs="+", help="Path(s) to input audio file(s)"
+        "audio", nargs="+", help="Path(s) to input media file(s) or directories"
     )
     parser.add_argument(
         "-o",
@@ -112,17 +173,33 @@ def main() -> None:
         default=0.2,
         help="Pause threshold (seconds) to start a new chunk",
     )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="Recursively search directories for media files",
+    )
 
     args = parser.parse_args()
 
-    if len(args.audio) > 1 and args.output:
-        parser.error("--output can only be used with a single input audio")
+    try:
+        audio_inputs = collect_media_paths(args.audio, args.recursive)
+    except (FileNotFoundError, ValueError) as exc:
+        parser.error(str(exc))
+
+    if not audio_inputs:
+        parser.error(
+            "No audio or video files without adjacent SRT subtitles were found."
+        )
+
+    if args.output and len(audio_inputs) > 1:
+        parser.error("--output can only be used with a single input media file")
 
     if args.hf_token:
         os.environ["HF_TOKEN"] = args.hf_token
 
     model = gigaam.load_model(args.model, device=args.device)
-    for audio_path in args.audio:
+    for audio_path in audio_inputs:
         wav_path, is_temp = ensure_wav(audio_path)
         try:
             segments = model.transcribe_longform(


### PR DESCRIPTION
## Summary
- allow passing directories and optional recursive search for media inputs
- only queue media files that lack a sibling SRT subtitle
- document the new behaviour and options in the README

## Testing
- python -m py_compile transcribe.py

------
https://chatgpt.com/codex/tasks/task_e_68cadfc753548333bd0351406081778f